### PR TITLE
Remove modsulator-app

### DIFF
--- a/autoupdate.sh
+++ b/autoupdate.sh
@@ -17,7 +17,6 @@ goobi-robot
 hydra_etd
 hydrus
 item-release
-modsulator-app
 modsulator-app-rails
 preservation_catalog
 pre-assembly


### PR DESCRIPTION
That is now deprecated. We use modsulator-app-rails instead.