### PR TITLE
Update gem grant/revoke utility

### DIFF
--- a/grant_revoke_gem_authority.rb
+++ b/grant_revoke_gem_authority.rb
@@ -20,42 +20,50 @@ require 'github_api'
 require 'open3'
 
 AUTHORIZATION_TOKEN = ENV['GITHUB_TOKEN'] || raise("GitHub authorization token was not found in the GITHUB_TOKEN environment variable")
-ORGANIZATION_NAMES = ['sul-dlss']
+ORGANIZATION_NAME = 'sul-dlss'
 # Some GitHub user instances do not have an email address defined,
 # so start with the prior list of addresses (registered with Rubygems.org)
 KNOWN_COMMITTER_EMAIL_ADDRESSES = {
-  'jmartin-sul' => 'john.martin@stanford.edu',
-  'mjgiarlo' => 'leftwing@alumni.rutgers.edu',
+  'aaron-collier' => 'aaron.collier@stanford.edu',
+  'aeschylus' => 'scipioaffricanus@gmail.com',
+  'anarchivist' => 'mark.matienzo@gmail.com',
+  'atz' => 'ohiocore@gmail.com',
+  'jcoyne' => 'digger250@gmail.com',
   'jermnelson' => 'jermnelson@gmail.com',
-  'jkeck' => 'jessie.keck@gmail.com'
+  'jkeck' => 'jessie.keck@gmail.com',
+  'jmartin-sul' => 'john.martin@stanford.edu',
+  'justinlittman' => 'justinlittman@gmail.com',
+  'mejackreed' => 'phillipjreed@gmail.com',
+  'mjgiarlo' => 'leftwing@alumni.rutgers.edu',
+  'ndushay' => 'ndushay@stanford.edu',
+  'peetucket' => 'peter@mangiafico.org',
+  'sul-devops-team' => 'sul-devops-team@lists.stanford.edu'
 }
 # Some GitHub repositories are named differently from their gems
 KNOWN_MISMATCHED_GEM_NAMES = { }
 # GitHub repositories with matching gems that aren't from sul-dlss
-FALSE_POSITIVES = %w[microservices argo eadsax sir-trevor-rails assembly
-  stacks media swap quimby Jcrop]
+FALSE_POSITIVES = %w[microservices argo eadsax sir-trevor-rails assembly stacks media swap quimby Jcrop gssapi osullivan rialto robot-master]
 # Gems that do not have their own GitHub repositories
 HANGERS_ON = []
-# Email addresses that are known not to be registered at rubygems.organization
-SKIP_EMAILS = []
+# Email addresses that are known not to be registered at rubygems.org
+SKIP_EMAILS = %w[ggeisler@gmail.com ]
 VERBOSE = ENV.fetch('VERBOSE', false)
+WITH_REVOKE = ENV.fetch('WITH_REVOKE', false)
 
 puts "(Hang in there! This script takes a couple minutes to run.)"
 
 github = Github.new(oauth_token: AUTHORIZATION_TOKEN, auto_pagination: true)
 
-# Get the ID of the GitHub-provided "Owners" team from the samvera org
-# We don't currently grant gem ownership to the folks in the other two orgs
-# (This just preserves the prior behavior.)
-org = github.orgs.teams.list(org: 'sul-dlss')
+# Get the IDs of the Access and Infra GitHub teams from the sul-dlss org
+org = github.orgs.teams.list(org: ORGANIZATION_NAME)
 access_team_id = org.select { |team| team.name == 'Access Team' }.first.id
 infra_team_id = org.select { |team| team.name == 'Infrastructure Team' }.first.id
 
-owners = github.orgs.teams.list_members(access_team_id).to_a + github.orgs.teams.list_members(infra_team_id).to_a
+team_members = github.orgs.teams.list_members(access_team_id).to_a + github.orgs.teams.list_members(infra_team_id).to_a
 # Start with the prior (known to work) list of email addresses
 committer_map = KNOWN_COMMITTER_EMAIL_ADDRESSES.dup
-owners.each do |owner|
-  user = github.users.get(user: owner.login)
+team_members.each do |member|
+  user = github.users.get(user: member.login)
   # Move along if the user doesn't have an email addy or if there's already an entry in the map
   next if !user.respond_to?(:email) || user.email.nil? || user.email.empty? || !committer_map[user.login].nil?
   committer_map[user.login] = user.email
@@ -76,16 +84,14 @@ def replace_known_mismatch(name)
   KNOWN_MISMATCHED_GEM_NAMES.fetch(name, name)
 end
 
-ORGANIZATION_NAMES.each do |org_name|
-  github.repos.list(org: org_name).each do |repo|
-    puts "Looking at #{repo.name}"
-    name = replace_known_mismatch(repo.name)
-    if exists?(name)
-      puts "      Found #{name}"
-      @gem_names << name
-    else
-      @bogus_gem_names << repo.full_name
-    end
+github.repos.list(org: ORGANIZATION_NAME).each do |repo|
+  puts "Looking at #{repo.name}" if VERBOSE
+  name = replace_known_mismatch(repo.name)
+  if exists?(name)
+    puts "\tFound #{name}" if VERBOSE
+    @gem_names << name
+  else
+    @bogus_gem_names << repo.full_name
   end
 end
 
@@ -101,8 +107,8 @@ end
   current_committers = `gem owner #{gemname} | grep -e ^-`.split("\n")
   current_committers.collect! { |cc| cc.sub(/^.\s+/,'')}
 
-  if ENV.fetch('WITH_REVOKE', false)
-    puts "Gem: #{gemname}"
+  if WITH_REVOKE
+    puts "Gem: #{gemname}" if VERBOSE
     committers_to_remove = current_committers - committer_emails
     remove_params = committers_to_remove.map { |email| "-r #{email}" }.join(' ')
     gem_owner_with_error_check(gemname, remove_params)
@@ -113,7 +119,7 @@ end
   gem_owner_with_error_check(gemname, add_params)
 end
 
-if @bogus_gem_names.any?
+if @bogus_gem_names.any? && VERBOSE
   $stderr.puts("WARNING: These repositories do not have gems:\n - #{@bogus_gem_names.sort.join("\n - ")}")
   $stderr.puts("\n")
 end


### PR DESCRIPTION
* Simplify script to care only about one organization name (no current need to handle multiple orgs like Samvera does)
* Add missing Infra/Access team GitHub username -> rubygems.org email address mappings to ensure all team engineers have the ability to cut releases
* Add osullivan, gssapi, rialto, and robot-master to false positives (none of these are gems we maintain)
* Clean up/correct code comments
* Use VERBOSE flag to determine whether to emit non-critical messages